### PR TITLE
feat(flow): support variable groups and pipeline relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,9 @@ alibabacloud-devops-mcp-server integrates various tools, including:
 - `generate_pipeline_yaml`: [Pipeline Management] Generate pipeline YAML configuration
 - `create_pipeline_from_description`: Create a pipeline from natural language description
 - `update_pipeline`: [Pipeline Management] Update pipeline YAML content
+- `list_flow_variable_groups`: [Pipeline Management] List Flow pipeline variable groups in an organization
+- `create_flow_variable_group`: [Pipeline Management] Create a Flow pipeline variable group for reusable pipeline variables and secrets
+- `add_pipeline_relations`: [Pipeline Management] Add pipeline-object relations, such as attaching a Flow variable group to a pipeline
 - `create_pipeline_run`: Create a pipeline run instance
 - `get_latest_pipeline_run`: Get the latest pipeline run instance
 - `get_pipeline_run`: Get pipeline run details

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -395,6 +395,9 @@ alibabacloud-devops-mcp-server集成了多种工具，包括：
 - `generate_pipeline_yaml` - [流水线管理] 生成流水线YAML配置
 - `create_pipeline_from_description` - 根据自然语言描述生成流水线 YAML 并创建流水线
 - `update_pipeline` - [流水线管理] 更新流水线YAML内容
+- `list_flow_variable_groups` - [流水线管理] 列出组织中的 Flow 流水线变量组
+- `create_flow_variable_group` - [流水线管理] 创建可复用的 Flow 流水线变量组和密钥
+- `add_pipeline_relations` - [流水线管理] 添加流水线对象关联，例如将 Flow 变量组绑定到流水线
 - `create_pipeline_run` - 运行流水线
 - `get_latest_pipeline_run` - 获取最新运行信息
 - `get_pipeline_run` - 获取运行详情

--- a/common/types.ts
+++ b/common/types.ts
@@ -138,6 +138,10 @@ export {
   GetPipelineRunSchema,
   ListPipelineRunsSchema,
   UpdatePipelineSchema,
+  FlowVariableGroupSchema,
+  ListFlowVariableGroupsSchema,
+  CreateFlowVariableGroupSchema,
+  AddPipelineRelationsSchema,
   
   // Pipeline job schemas
   ListPipelineJobsByCategorySchema,

--- a/operations/flow/types.ts
+++ b/operations/flow/types.ts
@@ -396,6 +396,47 @@ export const UpdatePipelineSchema = z.object({
   name: z.string().max(60).describe("Pipeline name, max 60 chars")
 });
 
+// Flow variable group schemas
+export const FlowVariableSchema = z.object({
+  name: z.string().describe("Variable name"),
+  value: z.string().describe("Variable value"),
+  isEncrypted: z.boolean().optional().describe("Whether the variable value should be stored as encrypted"),
+});
+
+export const FlowVariableGroupSchema = z.object({
+  creatorAccountId: z.string().nullable().optional().describe("Creator account ID"),
+  description: z.string().nullable().optional().describe("Variable group description"),
+  updateTime: z.number().int().nullable().optional().describe("Update time in milliseconds"),
+  id: z.number().int().nullable().optional().describe("Variable group ID"),
+  modifierAccountId: z.string().nullable().optional().describe("Last modifier account ID"),
+  name: z.string().nullable().optional().describe("Variable group name"),
+  relatedPipelines: z.array(z.any()).nullable().optional().describe("Pipelines related to the variable group"),
+  variables: z.array(FlowVariableSchema).nullable().optional().describe("Variables in the variable group"),
+  createTime: z.number().int().nullable().optional().describe("Create time in milliseconds"),
+});
+
+export const ListFlowVariableGroupsSchema = z.object({
+  organizationId: z.string().describe("Organization ID"),
+  perPage: z.number().int().min(1).max(100).default(20).optional().describe("Number of items per page"),
+  page: z.number().int().min(1).default(1).optional().describe("Page number"),
+  pageSort: z.string().optional().describe("Sort field, for example ID"),
+  pageOrder: z.enum(["DESC", "ASC"]).optional().describe("Sort order"),
+});
+
+export const CreateFlowVariableGroupSchema = z.object({
+  organizationId: z.string().describe("Organization ID"),
+  name: z.string().describe("Variable group name"),
+  description: z.string().optional().describe("Variable group description"),
+  variables: z.array(FlowVariableSchema).min(1).describe("Variables to create in the variable group"),
+});
+
+export const AddPipelineRelationsSchema = z.object({
+  organizationId: z.string().describe("Organization ID"),
+  pipelineId: z.string().describe("Pipeline ID"),
+  relObjectType: z.enum(["VARIABLE_GROUP"]).describe("Related object type"),
+  relObjectIds: z.array(z.string()).min(1).describe("Related object IDs"),
+});
+
 // Service Connection related types
 export const ServiceConnectionSchema = z.object({
   createTime: z.number().int().nullable().optional().describe("创建时间 (毫秒时间戳)"),
@@ -653,3 +694,8 @@ export type ListPipelineRunsOptions = z.infer<typeof ListPipelineRunsSchema>;
 export type PipelineJobItem = z.infer<typeof PipelineJobItemSchema>;
 export type PipelineJobHistoryItem = z.infer<typeof PipelineJobHistoryItemSchema>;
 export type PipelineJobRunLog = z.infer<typeof PipelineJobRunLogSchema>;
+export type FlowVariable = z.infer<typeof FlowVariableSchema>;
+export type FlowVariableGroup = z.infer<typeof FlowVariableGroupSchema>;
+export type ListFlowVariableGroupsParams = z.infer<typeof ListFlowVariableGroupsSchema>;
+export type CreateFlowVariableGroupParams = z.infer<typeof CreateFlowVariableGroupSchema>;
+export type AddPipelineRelationsParams = z.infer<typeof AddPipelineRelationsSchema>;

--- a/operations/flow/variableGroup.ts
+++ b/operations/flow/variableGroup.ts
@@ -1,0 +1,79 @@
+import * as utils from "../../common/utils.js";
+import { resolveOrganizationId } from "../organization/organization.js";
+import {
+  AddPipelineRelationsParams,
+  FlowVariableGroupSchema,
+  FlowVariableGroup,
+  CreateFlowVariableGroupParams,
+  ListFlowVariableGroupsParams,
+} from "./types.js";
+
+export async function listFlowVariableGroupsFunc(
+  organizationId: string | undefined,
+  options?: Omit<ListFlowVariableGroupsParams, "organizationId">,
+): Promise<FlowVariableGroup[]> {
+  const finalOrgId = await resolveOrganizationId(organizationId);
+  const baseUrl = utils.isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups`;
+
+  const url = utils.buildUrl(baseUrl, {
+    perPage: options?.perPage,
+    page: options?.page,
+    pageSort: options?.pageSort,
+    pageOrder: options?.pageOrder,
+  });
+
+  const response = await utils.yunxiaoRequest(url, {
+    method: "GET",
+  });
+
+  if (!Array.isArray(response)) {
+    return [];
+  }
+
+  return response.map(item => FlowVariableGroupSchema.parse(item));
+}
+
+export async function createFlowVariableGroupFunc(
+  params: CreateFlowVariableGroupParams,
+): Promise<number> {
+  const { organizationId, name, description, variables } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+  const baseUrl = utils.isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups`;
+
+  const url = utils.buildUrl(baseUrl, {
+    name,
+    description,
+    variables: JSON.stringify(variables),
+  });
+
+  const response = await utils.yunxiaoRequest(url, {
+    method: "POST",
+  });
+
+  return Number(response);
+}
+
+export async function addPipelineRelationsFunc(
+  params: AddPipelineRelationsParams,
+): Promise<boolean> {
+  const { organizationId, pipelineId, relObjectType, relObjectIds } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+  const baseUrl = utils.isRegionEdition()
+    ? `/oapi/v1/flow/pipelines/${pipelineId}/pipelineObjRel/add`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/pipelines/${pipelineId}/pipelineObjRel/add`;
+
+  const url = utils.buildUrl(baseUrl, {
+    relObjectType,
+    relObjectIds: relObjectIds.join(","),
+  });
+
+  const response = await utils.yunxiaoRequest(url, {
+    method: "POST",
+  });
+
+  return response === true || response === "true";
+}

--- a/tool-handlers/pipeline.ts
+++ b/tool-handlers/pipeline.ts
@@ -1,5 +1,6 @@
 import * as pipeline from '../operations/flow/pipeline.js';
 import * as pipelineJob from '../operations/flow/pipelineJob.js';
+import * as flowVariableGroup from '../operations/flow/variableGroup.js';
 import * as types from '../common/types.js';
 import { z } from 'zod';
 
@@ -357,6 +358,35 @@ export const handlePipelineTools = async (request: any) => {
       );
       return {
         content: [{ type: "text", text: JSON.stringify({ success: result }) }]
+      };
+    }
+
+    case "list_flow_variable_groups": {
+      const args = types.ListFlowVariableGroupsSchema.parse(request.params.arguments);
+      const result = await flowVariableGroup.listFlowVariableGroupsFunc(args.organizationId, {
+        perPage: args.perPage,
+        page: args.page,
+        pageSort: args.pageSort,
+        pageOrder: args.pageOrder,
+      });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    }
+
+    case "create_flow_variable_group": {
+      const args = types.CreateFlowVariableGroupSchema.parse(request.params.arguments);
+      const result = await flowVariableGroup.createFlowVariableGroupFunc(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    }
+
+    case "add_pipeline_relations": {
+      const args = types.AddPipelineRelationsSchema.parse(request.params.arguments);
+      const result = await flowVariableGroup.addPipelineRelationsFunc(args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };
     }
 

--- a/tool-registry/pipeline.ts
+++ b/tool-registry/pipeline.ts
@@ -190,4 +190,19 @@ export const getPipelineTools = () => [
     description: "[Pipeline Management] Update an existing pipeline in Yunxiao by pipelineId. Use this to update pipeline YAML, stages, jobs, etc.",
     inputSchema: zodToJsonSchema(types.UpdatePipelineSchema),
   },
+  {
+    name: "list_flow_variable_groups",
+    description: "[Pipeline Management] List Flow pipeline variable groups in an organization.",
+    inputSchema: zodToJsonSchema(types.ListFlowVariableGroupsSchema),
+  },
+  {
+    name: "create_flow_variable_group",
+    description: "[Pipeline Management] Create a Flow pipeline variable group for reusable pipeline variables and secrets.",
+    inputSchema: zodToJsonSchema(types.CreateFlowVariableGroupSchema),
+  },
+  {
+    name: "add_pipeline_relations",
+    description: "[Pipeline Management] Add pipeline-object relations. Use this to attach a Flow variable group to a pipeline.",
+    inputSchema: zodToJsonSchema(types.AddPipelineRelationsSchema),
+  },
 ];


### PR DESCRIPTION
## Summary
- add Flow pipeline variable group schemas and operations
- register `list_flow_variable_groups`, `create_flow_variable_group`, and `add_pipeline_relations`
- document the new pipeline-management tools in both README files

## Why
The MCP already supports pipeline CRUD and app delivery variable groups, but it does not cover the Flow variable-group workflow that teams use to attach reusable secrets and variables to pipelines.

This closes the gap needed for a common release flow:
1. create a Flow variable group
2. attach it to a pipeline
3. run the pipeline with reusable variables injected automatically

## Validation
- `npm run build`
- read-only smoke check against a real Yunxiao org by calling the new `listFlowVariableGroupsFunc` after build
