### PR TITLE
Pipeline: add stop_pipeline_job_run tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ alibabacloud-devops-mcp-server integrates various tools, including:
 - `list_pipeline_jobs_by_category`: Get pipeline execution tasks by category
 - `list_pipeline_job_historys`: Get the execution history of a pipeline task
 - `execute_pipeline_job_run`: Manually run a pipeline task
+- `stop_pipeline_job_run`: Stop a specific job in a pipeline run instance
 - `get_pipeline_job_run_log`: Get the execution logs of a pipeline job
 - `list_service_connections`: List service connections in organization
 - `create_pipeline_from_description`: Automatically generates YAML configuration and creates pipeline

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -402,6 +402,7 @@ alibabacloud-devops-mcp-server集成了多种工具，包括：
 - `list_pipeline_jobs_by_category` - 获取流水线任务
 - `list_pipeline_job_historys` - 获取任务历史
 - `execute_pipeline_job_run` - 手动运行任务
+- `stop_pipeline_job_run` - 停止指定的流水线任务
 - `get_pipeline_job_run_log` - 获取任务日志
 - `list_service_connections` - 获取服务连接列表
 - `create_pipeline_from_description`: 根据自然语言描述生成流水线 YAML 并创建流水线

--- a/common/types.ts
+++ b/common/types.ts
@@ -143,6 +143,7 @@ export {
   ListPipelineJobsByCategorySchema,
   ListPipelineJobHistorysSchema,
   ExecutePipelineJobRunSchema,
+  StopPipelineJobRunSchema,
   GetPipelineJobRunLogSchema,
   
   // Service connection schemas

--- a/operations/flow/pipelineJob.ts
+++ b/operations/flow/pipelineJob.ts
@@ -163,6 +163,32 @@ export async function executePipelineJobRunFunc(
 }
 
 /**
+ * 停止流水线任务运行
+ * @param organizationId Organization ID（组织ID）
+ * @param pipelineId Pipeline ID（流水线ID）
+ * @param pipelineRunId Pipeline run instance ID（流水线运行ID）
+ * @param jobId Job ID for the pipeline run task（流水线运行任务ID）
+ * @returns Whether the operation was successful
+ */
+export async function stopPipelineJobRunFunc(
+  organizationId: string | undefined,
+  pipelineId: string,
+  pipelineRunId: string,
+  jobId: string
+): Promise<boolean> {
+  const finalOrgId = await resolveOrganizationId(organizationId);
+  const url = utils.isRegionEdition()
+    ? `/oapi/v1/flow/pipelines/${pipelineId}/pipelineRuns/${pipelineRunId}/jobs/${jobId}/stop`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/pipelines/${pipelineId}/pipelineRuns/${pipelineRunId}/jobs/${jobId}/stop`;
+
+  const response = await utils.yunxiaoRequest(url, {
+    method: "PUT",
+  });
+
+  return Boolean(response);
+}
+
+/**
  * 查询任务运行日志
  * @param organizationId Organization ID（组织ID）
  * @param pipelineId Pipeline ID（流水线ID）
@@ -187,4 +213,3 @@ export async function getPipelineJobRunLogFunc(
 
   return PipelineJobRunLogSchema.parse(response);
 }
-

--- a/operations/flow/types.ts
+++ b/operations/flow/types.ts
@@ -343,6 +343,14 @@ export const ExecutePipelineJobRunSchema = z.object({
   jobId: z.string().describe("Job ID for the pipeline run task")
 });
 
+// Flow Stop pipeline job run schema
+export const StopPipelineJobRunSchema = z.object({
+  organizationId: z.string().describe("Organization ID, can be found in the basic information page of the organization admin console"),
+  pipelineId: z.string().describe("Pipeline ID"),
+  pipelineRunId: z.string().describe("Pipeline run instance ID"),
+  jobId: z.string().describe("Job ID for the pipeline run task")
+});
+
 // Flow Get pipeline job run log schema
 export const GetPipelineJobRunLogSchema = z.object({
   organizationId: z.string().describe("Organization ID, can be found in the basic information page of the organization admin console"),

--- a/tool-handlers/pipeline.ts
+++ b/tool-handlers/pipeline.ts
@@ -334,6 +334,19 @@ export const handlePipelineTools = async (request: any) => {
       };
     }
 
+    case "stop_pipeline_job_run": {
+      const args = types.StopPipelineJobRunSchema.parse(request.params.arguments);
+      const result = await pipelineJob.stopPipelineJobRunFunc(
+        args.organizationId,
+        args.pipelineId,
+        args.pipelineRunId,
+        args.jobId
+      );
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    }
+
     case "get_pipeline_job_run_log": {
       const args = types.GetPipelineJobRunLogSchema.parse(request.params.arguments);
       const log = await pipelineJob.getPipelineJobRunLogFunc(

--- a/tool-registry/pipeline.ts
+++ b/tool-registry/pipeline.ts
@@ -181,6 +181,11 @@ export const getPipelineTools = () => [
     inputSchema: zodToJsonSchema(types.ExecutePipelineJobRunSchema),
   },
   {
+    name: "stop_pipeline_job_run",
+    description: "[Pipeline Management] Stop a specific job in a pipeline run instance. Use this when a job is stuck or when a newer run is blocked behind an older one.",
+    inputSchema: zodToJsonSchema(types.StopPipelineJobRunSchema),
+  },
+  {
     name: "get_pipeline_job_run_log",
     description: "[Pipeline Management] Get the execution logs of a pipeline job. Retrieve the log content for a specific job in a pipeline run.",
     inputSchema: zodToJsonSchema(types.GetPipelineJobRunLogSchema),


### PR DESCRIPTION
## Summary
- add a Flow `stop_pipeline_job_run` tool for stopping a specific pipeline job run
- wire the new schema through the flow operation, common exports, tool registry, and pipeline handler
- document the new pipeline-management tool in both README files

## Why
During real Yunxiao pipeline diagnosis, the MCP server could inspect pipeline runs and job logs but could not stop a stuck job. In practice this meant falling back to the Flow OpenAPI `StopPipelineJobRun` endpoint to clear an older blocked run so the queued rerun could start.

Adding a dedicated tool closes that gap without expanding into broader pipeline-control APIs.

## Validation
- `npm install`
- `npm run build`
- verified the built pipeline registry includes `stop_pipeline_job_run`
