### PR TITLE
feat: add create_repository tool for creating Codeup repositories

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -49,6 +49,7 @@ export {
   // Repository schemas
   GetRepositorySchema,
   ListRepositoriesSchema,
+  CreateRepositorySchema,
   
   // Compare schemas
   GetCompareSchema,

--- a/operations/codeup/repositories.ts
+++ b/operations/codeup/repositories.ts
@@ -11,8 +11,9 @@
 import { z } from "zod";
 import {yunxiaoRequest, buildUrl, handleRepositoryIdEncoding, isRegionEdition} from "../../common/utils.js";
 import { resolveOrganizationId } from "../organization/organization.js";
-import { 
-  RepositorySchema
+import {
+  RepositorySchema,
+  CreateRepositorySchema
 } from "./types.js";
 
 
@@ -100,4 +101,37 @@ export async function listRepositoriesFunc(
   }
 
   return response.map(repo => RepositorySchema.parse(repo));
+}
+
+/**
+ * 创建代码库
+ * @param organizationId
+ * @param params
+ */
+export async function createRepositoryFunc(
+  organizationId: string | undefined,
+  params: z.infer<typeof CreateRepositorySchema>
+): Promise<z.infer<typeof RepositorySchema>> {
+  const finalOrgId = await resolveOrganizationId(organizationId);
+  const baseUrl = isRegionEdition()
+    ? `/oapi/v1/codeup/organizations/repositories`
+    : `/oapi/v1/codeup/organizations/${finalOrgId}/repositories`;
+
+  const body: Record<string, unknown> = {
+    name: params.name,
+  };
+  if (params.path) body.path = params.path;
+  if (params.description) body.description = params.description;
+  if (params.visibility) body.visibility = params.visibility;
+  if (params.namespaceId) body.namespaceId = params.namespaceId;
+  if (params.readMeType) body.readMeType = params.readMeType;
+
+  const url = buildUrl(baseUrl, { createParentPath: "true" });
+
+  const response = await yunxiaoRequest(url, {
+    method: "POST",
+    body,
+  });
+
+  return RepositorySchema.parse(response);
 } 

--- a/operations/codeup/types.ts
+++ b/operations/codeup/types.ts
@@ -260,6 +260,16 @@ export const ListRepositoriesSchema = z.object({
   archived: z.boolean().default(false).optional().describe("Whether archived"),
 });
 
+export const CreateRepositorySchema = z.object({
+  organizationId: z.string().describe("Organization ID, can be found in the basic information page of the organization admin console"),
+  name: z.string().describe("Repository name, e.g. my-repo"),
+  path: z.string().optional().describe("Repository path, defaults to the same as name"),
+  description: z.string().optional().describe("Repository description, max 65535 characters"),
+  visibility: z.enum(["private", "internal", "public"]).optional().default("private").describe("Repository visibility: private, internal, or public"),
+  namespaceId: z.number().int().optional().describe("Parent path ID (namespace). If empty, created under the organization root"),
+  readMeType: z.enum(["EMPTY", "USER_GUIDE"]).optional().describe("Type of README to auto-create: EMPTY or USER_GUIDE"),
+});
+
 // Codeup files related Schema definitions
 export const GetFileBlobsSchema = z.object({
   organizationId: z.string().describe("Organization ID, can be found in the basic information page of the organization admin console"),

--- a/tool-handlers/code-management.ts
+++ b/tool-handlers/code-management.ts
@@ -181,6 +181,17 @@ export const handleCodeManagementTools = async (request: any) => {
       };
     }
 
+    case "create_repository": {
+      const args = types.CreateRepositorySchema.parse(request.params.arguments);
+      const repository = await repositories.createRepositoryFunc(
+        args.organizationId,
+        args
+      );
+      return {
+        content: [{ type: "text", text: JSON.stringify(repository, null, 2) }],
+      };
+    }
+
     // Change Request Operations
     case "get_change_request": {
       const args = types.GetChangeRequestSchema.parse(request.params.arguments);

--- a/tool-registry/code-management.ts
+++ b/tool-registry/code-management.ts
@@ -74,6 +74,17 @@ export const getCodeManagementTools = () => [
       "View my repositories",
     inputSchema: zodToJsonSchema(types.ListRepositoriesSchema),
   },
+  {
+    name: "create_repository",
+    description: "[Code Management] Create a new Codeup repository.\n" +
+      "\n" +
+      "Creates an empty code repository that can then be pushed to via git.\n" +
+      "\n" +
+      "Use Cases:\n" +
+      "\n" +
+      "Create a new repository for a project",
+    inputSchema: zodToJsonSchema(types.CreateRepositorySchema),
+  },
 
   // Change Request Operations
   {


### PR DESCRIPTION
## Summary

Adds a `create_repository` tool to the code management toolset, enabling AI assistants to create new Codeup repositories.

## API

`POST /oapi/v1/codeup/organizations/repositories` with `x-yunxiao-token` auth.

## Changes

| File | Change |
|------|--------|
| `operations/codeup/types.ts` | Added `CreateRepositorySchema` |
| `common/types.ts` | Re-exported `CreateRepositorySchema` |
| `operations/codeup/repositories.ts` | Added `createRepositoryFunc` |
| `tool-registry/code-management.ts` | Registered `create_repository` tool |
| `tool-handlers/code-management.ts` | Added handler case |

## Params

- `name` (required) - Repository name
- `path` (optional) - Repository path
- `description` (optional)
- `visibility` (optional, default: private) - private/internal/public
- `namespaceId` (optional) - Parent path ID
- `readMeType` (optional) - EMPTY or USER_GUIDE