### PR TITLE
fix: 修复通过 npx 运行时 package.json 路径解析问题

### DIFF
--- a/common/version.ts
+++ b/common/version.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const pkg = require("../package.json");
+const pkg = require("../../package.json");
 
 export const VERSION = pkg.version;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "alibabacloud-devops-mcp-server": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "package.json"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 问题描述

通过 `npx` 运行时，`dist/common/version.js` 尝试 `require('../package.json')`，
但路径解析失败导致服务崩溃：

    Error: Cannot find module '../package.json'

Fixes #61

## 解决方案

1. 将 `package.json` 添加到 `files` 数组，使其随 `dist/` 一起发布
2. 修正 require 路径从 `../package.json` 改为 `../../package.json`，
   以正确从 `dist/common/version.js` 解析到根目录的 `package.json`

## 修改内容

- `package.json`: 在 `files` 数组中添加 `"package.json"`
- `common/version.ts`: 将 require 路径从 `"../package.json"` 改为 `"../../package.json"`

## 测试

已通过打包并在隔离环境中运行验证修复有效。
