### PR TITLE
feat: add Flow pipeline variable group management tools

### DIFF
--- a/common/toolsetManager.ts
+++ b/common/toolsetManager.ts
@@ -21,6 +21,7 @@ import { getAppStackAppReleaseWorkflowTools } from '../tool-registry/appstack-ap
 import { getEffortTools } from '../tool-registry/effort.js';
 import { getResourceMemberTools } from '../tool-registry/resourceMember.js';
 import { getVMDeployOrderTools } from '../tool-registry/vmDeployOrder.js';
+import { getFlowVariableGroupTools } from '../tool-registry/flow-variable-groups.js';
 import { getCommitTools } from '../tool-registry/commit.js';
 import { getBaseTools } from '../tool-registry/base.js';
 import { getTestManagementTools } from '../tool-registry/test-management.js';
@@ -69,7 +70,8 @@ const ALL_TOOLSET_CONFIGS: Record<Toolset, ToolsetConfig> = {
       ...getPipelineTools(),
       ...getServiceConnectionTools(),
       ...getResourceMemberTools(),
-      ...getVMDeployOrderTools()
+      ...getVMDeployOrderTools(),
+      ...getFlowVariableGroupTools()
     ]) as () => Tool[]
   },
   [Toolset.PACKAGES_MANAGEMENT]: {

--- a/operations/flow/variableGroups.ts
+++ b/operations/flow/variableGroups.ts
@@ -1,0 +1,181 @@
+import { z } from 'zod';
+import { yunxiaoRequest, isRegionEdition } from '../../common/utils.js';
+import { resolveOrganizationId } from '../organization/organization.js';
+
+const PipelineRefSchema = z.object({
+  id: z.number().describe("流水线ID"),
+  name: z.string().describe("流水线名称"),
+}).describe("关联流水线信息");
+
+const VariableSchema = z.object({
+  name: z.string().describe("变量名"),
+  value: z.string().describe("变量值"),
+  isEncrypted: z.boolean().optional().describe("是否加密"),
+}).describe("变量信息");
+
+const VariableGroupSchema = z.object({
+  id: z.number().describe("变量组ID"),
+  name: z.string().describe("变量组名称"),
+  description: z.string().nullable().optional().describe("变量组描述"),
+  creatorAccountId: z.string().optional().describe("创建者账号ID"),
+  modifierAccountId: z.string().optional().describe("修改者账号ID"),
+  createTime: z.number().optional().describe("创建时间（毫秒时间戳）"),
+  updateTime: z.number().optional().describe("更新时间（毫秒时间戳）"),
+  relatedPipelines: z.array(PipelineRefSchema).optional().describe("关联流水线列表"),
+  variables: z.array(VariableSchema).optional().describe("变量列表"),
+}).describe("流水线变量组");
+
+export const ListFlowVariableGroupsRequestSchema = z.object({
+  organizationId: z.string().optional().describe("组织ID（中心站必填，区域站可省略）"),
+});
+
+export const ListFlowVariableGroupsResponseSchema = z.array(VariableGroupSchema);
+
+export const GetFlowVariableGroupRequestSchema = z.object({
+  organizationId: z.string().optional().describe("组织ID（中心站必填，区域站可省略）"),
+  id: z.number().describe("变量组ID"),
+});
+
+export const GetFlowVariableGroupResponseSchema = VariableGroupSchema;
+
+export const CreateFlowVariableGroupRequestSchema = z.object({
+  organizationId: z.string().optional().describe("组织ID（中心站必填，区域站可省略）"),
+  name: z.string().describe("变量组名称"),
+  description: z.string().optional().describe("变量组描述"),
+  variables: z.array(VariableSchema).describe("变量列表"),
+});
+
+export const CreateFlowVariableGroupResponseSchema = z.number().describe("创建的变量组ID");
+
+export const UpdateFlowVariableGroupRequestSchema = z.object({
+  organizationId: z.string().optional().describe("组织ID（中心站必填，区域站可省略）"),
+  id: z.number().describe("变量组ID"),
+  name: z.string().describe("变量组名称"),
+  description: z.string().optional().describe("变量组描述"),
+  variables: z.array(VariableSchema).describe("变量列表"),
+});
+
+export const UpdateFlowVariableGroupResponseSchema = z.boolean().describe("更新是否成功");
+
+export const DeleteFlowVariableGroupRequestSchema = z.object({
+  organizationId: z.string().optional().describe("组织ID（中心站必填，区域站可省略）"),
+  id: z.number().describe("变量组ID"),
+});
+
+export const DeleteFlowVariableGroupResponseSchema = z.boolean().describe("删除是否成功");
+
+export type ListFlowVariableGroupsRequest = z.infer<typeof ListFlowVariableGroupsRequestSchema>;
+export type ListFlowVariableGroupsResponse = z.infer<typeof ListFlowVariableGroupsResponseSchema>;
+export type GetFlowVariableGroupRequest = z.infer<typeof GetFlowVariableGroupRequestSchema>;
+export type GetFlowVariableGroupResponse = z.infer<typeof GetFlowVariableGroupResponseSchema>;
+export type CreateFlowVariableGroupRequest = z.infer<typeof CreateFlowVariableGroupRequestSchema>;
+export type CreateFlowVariableGroupResponse = z.infer<typeof CreateFlowVariableGroupResponseSchema>;
+export type UpdateFlowVariableGroupRequest = z.infer<typeof UpdateFlowVariableGroupRequestSchema>;
+export type UpdateFlowVariableGroupResponse = z.infer<typeof UpdateFlowVariableGroupResponseSchema>;
+export type DeleteFlowVariableGroupRequest = z.infer<typeof DeleteFlowVariableGroupRequestSchema>;
+export type DeleteFlowVariableGroupResponse = z.infer<typeof DeleteFlowVariableGroupResponseSchema>;
+
+/**
+ * List Flow pipeline variable groups
+ *
+ * @param params - The request parameters
+ * @returns The list of pipeline variable groups
+ */
+export async function listFlowVariableGroups(params: ListFlowVariableGroupsRequest): Promise<ListFlowVariableGroupsResponse> {
+  const { organizationId } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+
+  const url = isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups`;
+
+  const response = await yunxiaoRequest(url, { method: 'GET' });
+  return ListFlowVariableGroupsResponseSchema.parse(response);
+}
+
+/**
+ * Get a Flow pipeline variable group by ID
+ *
+ * @param params - The request parameters
+ * @returns The variable group details
+ */
+export async function getFlowVariableGroup(params: GetFlowVariableGroupRequest): Promise<GetFlowVariableGroupResponse> {
+  const { organizationId, id } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+
+  const url = isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups/${id}`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups/${id}`;
+
+  const response = await yunxiaoRequest(url, { method: 'GET' });
+  return GetFlowVariableGroupResponseSchema.parse(response);
+}
+
+/**
+ * Create a Flow pipeline variable group
+ *
+ * @param params - The request parameters
+ * @returns The created variable group ID
+ */
+export async function createFlowVariableGroup(params: CreateFlowVariableGroupRequest): Promise<CreateFlowVariableGroupResponse> {
+  const { organizationId, name, description, variables } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+
+  const queryParams = new URLSearchParams();
+  queryParams.append('name', name);
+  if (description) queryParams.append('description', description);
+  queryParams.append('variables', JSON.stringify(variables));
+
+  const baseUrl = isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups`;
+
+  const url = `${baseUrl}?${queryParams.toString()}`;
+
+  const response = await yunxiaoRequest(url, { method: 'POST' });
+  // The API returns the ID as a plain text number
+  return CreateFlowVariableGroupResponseSchema.parse(response);
+}
+
+/**
+ * Update a Flow pipeline variable group
+ *
+ * @param params - The request parameters
+ * @returns Whether the update was successful
+ */
+export async function updateFlowVariableGroup(params: UpdateFlowVariableGroupRequest): Promise<UpdateFlowVariableGroupResponse> {
+  const { organizationId, id, name, description, variables } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+
+  const queryParams = new URLSearchParams();
+  queryParams.append('name', name);
+  if (description) queryParams.append('description', description);
+  queryParams.append('variables', JSON.stringify(variables));
+
+  const baseUrl = isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups/${id}`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups/${id}`;
+
+  const url = `${baseUrl}?${queryParams.toString()}`;
+
+  const response = await yunxiaoRequest(url, { method: 'PUT' });
+  return UpdateFlowVariableGroupResponseSchema.parse(response);
+}
+
+/**
+ * Delete a Flow pipeline variable group
+ *
+ * @param params - The request parameters
+ * @returns Whether the deletion was successful
+ */
+export async function deleteFlowVariableGroup(params: DeleteFlowVariableGroupRequest): Promise<DeleteFlowVariableGroupResponse> {
+  const { organizationId, id } = params;
+  const finalOrgId = await resolveOrganizationId(organizationId);
+
+  const url = isRegionEdition()
+    ? `/oapi/v1/flow/variableGroups/${id}`
+    : `/oapi/v1/flow/organizations/${finalOrgId}/variableGroups/${id}`;
+
+  const response = await yunxiaoRequest(url, { method: 'DELETE' });
+  return DeleteFlowVariableGroupResponseSchema.parse(response);
+}

--- a/tool-handlers/flow-variable-groups.ts
+++ b/tool-handlers/flow-variable-groups.ts
@@ -1,0 +1,60 @@
+import {
+  listFlowVariableGroups,
+  getFlowVariableGroup,
+  createFlowVariableGroup,
+  updateFlowVariableGroup,
+  deleteFlowVariableGroup,
+  ListFlowVariableGroupsRequestSchema,
+  GetFlowVariableGroupRequestSchema,
+  CreateFlowVariableGroupRequestSchema,
+  UpdateFlowVariableGroupRequestSchema,
+  DeleteFlowVariableGroupRequestSchema,
+} from '../operations/flow/variableGroups.js';
+
+/**
+ * Handle the Flow pipeline variable groups tool requests
+ *
+ * @param request - The tool request
+ * @returns The tool response or null if not handled
+ */
+export async function handleFlowVariableGroupTools(request: any) {
+  switch (request.params.name) {
+    case 'list_flow_variable_groups':
+      const listParams = ListFlowVariableGroupsRequestSchema.parse(request.params.arguments);
+      const listResult = await listFlowVariableGroups(listParams);
+      return {
+        content: [{ type: "text", text: JSON.stringify(listResult, null, 2) }],
+      };
+
+    case 'get_flow_variable_group':
+      const getParams = GetFlowVariableGroupRequestSchema.parse(request.params.arguments);
+      const getResult = await getFlowVariableGroup(getParams);
+      return {
+        content: [{ type: "text", text: JSON.stringify(getResult, null, 2) }],
+      };
+
+    case 'create_flow_variable_group':
+      const createParams = CreateFlowVariableGroupRequestSchema.parse(request.params.arguments);
+      const createResult = await createFlowVariableGroup(createParams);
+      return {
+        content: [{ type: "text", text: JSON.stringify({ id: createResult }, null, 2) }],
+      };
+
+    case 'update_flow_variable_group':
+      const updateParams = UpdateFlowVariableGroupRequestSchema.parse(request.params.arguments);
+      const updateResult = await updateFlowVariableGroup(updateParams);
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: updateResult }, null, 2) }],
+      };
+
+    case 'delete_flow_variable_group':
+      const deleteParams = DeleteFlowVariableGroupRequestSchema.parse(request.params.arguments);
+      const deleteResult = await deleteFlowVariableGroup(deleteParams);
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: deleteResult }, null, 2) }],
+      };
+
+    default:
+      return null;
+  }
+}

--- a/tool-handlers/index.ts
+++ b/tool-handlers/index.ts
@@ -17,6 +17,7 @@ import { handleAppStackAppReleaseWorkflowTools } from './appstack-app-release-wo
 import { handleEffortTools } from './effort.js';
 import { handleResourceMemberTools } from './resourceMember.js';
 import { handleVMDeployOrderTools } from './vmDeployOrder.js';
+import { handleFlowVariableGroupTools } from './flow-variable-groups.js';
 import { handleCommitTools } from './commit.js';
 import { handleBaseTools } from './base.js';
 import { handleTestManagementTools } from './test-management.js';
@@ -59,7 +60,8 @@ const HANDLER_MAP: Record<Toolset, (request: any) => Promise<any>> = {
     handlePipelineTools,
     handleServiceConnectionTools,
     handleResourceMemberTools,
-    handleVMDeployOrderTools
+    handleVMDeployOrderTools,
+    handleFlowVariableGroupTools
   ),
   [Toolset.PACKAGES_MANAGEMENT]: handlePackageManagementTools,
   [Toolset.APPLICATION_DELIVERY]: composeHandlers(
@@ -102,7 +104,8 @@ export const handleToolRequest = async (request: any) => {
     handleResourceMemberTools,
     handleVMDeployOrderTools,
     handleCommitTools,
-    handleTestManagementTools
+    handleTestManagementTools,
+    handleFlowVariableGroupTools
   ];
 
   for (const handler of handlers) {

--- a/tool-registry/flow-variable-groups.ts
+++ b/tool-registry/flow-variable-groups.ts
@@ -1,0 +1,36 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  ListFlowVariableGroupsRequestSchema,
+  GetFlowVariableGroupRequestSchema,
+  CreateFlowVariableGroupRequestSchema,
+  UpdateFlowVariableGroupRequestSchema,
+  DeleteFlowVariableGroupRequestSchema,
+} from '../operations/flow/variableGroups.js';
+
+export const getFlowVariableGroupTools = () => [
+  {
+    name: 'list_flow_variable_groups',
+    description: '[Pipeline Management] List Flow pipeline variable groups (common variable groups)',
+    inputSchema: zodToJsonSchema(ListFlowVariableGroupsRequestSchema),
+  },
+  {
+    name: 'get_flow_variable_group',
+    description: '[Pipeline Management] Get a Flow pipeline variable group by ID',
+    inputSchema: zodToJsonSchema(GetFlowVariableGroupRequestSchema),
+  },
+  {
+    name: 'create_flow_variable_group',
+    description: '[Pipeline Management] Create a Flow pipeline variable group',
+    inputSchema: zodToJsonSchema(CreateFlowVariableGroupRequestSchema),
+  },
+  {
+    name: 'update_flow_variable_group',
+    description: '[Pipeline Management] Update a Flow pipeline variable group',
+    inputSchema: zodToJsonSchema(UpdateFlowVariableGroupRequestSchema),
+  },
+  {
+    name: 'delete_flow_variable_group',
+    description: '[Pipeline Management] Delete a Flow pipeline variable group',
+    inputSchema: zodToJsonSchema(DeleteFlowVariableGroupRequestSchema),
+  },
+];


### PR DESCRIPTION
Closes #65

Adds 5 new MCP tools for managing Flow pipeline variable groups (common variable groups):

- `list_flow_variable_groups` — List all pipeline variable groups
- `get_flow_variable_group` — Get a variable group by ID
- `create_flow_variable_group` — Create a new variable group with variables
- `update_flow_variable_group` — Update an existing variable group
- `delete_flow_variable_group` — Delete a variable group

These tools use the `/oapi/v1/flow/variableGroups` endpoints and are registered under the `pipeline-management` toolset.

### New files
- `operations/flow/variableGroups.ts`
- `tool-handlers/flow-variable-groups.ts`
- `tool-registry/flow-variable-groups.ts`

### Modified files
- `tool-handlers/index.ts`
- `common/toolsetManager.ts`
