### PR TITLE
fix: add missing fields to UpdateAppOrchestrationRequestSchema

### DIFF
--- a/operations/appstack/appOrchestrations.ts
+++ b/operations/appstack/appOrchestrations.ts
@@ -128,6 +128,11 @@ export const UpdateAppOrchestrationRequestSchema = z.object({
   fromRevisionSha: z.string().optional().describe("本次提交的基线版本 SHA 值"),
   name: z.string().describe("编排名"),
   spec: z.object({}).passthrough().optional().describe("编排规范"),
+  componentList: z.array(z.object({}).passthrough()).optional().describe("组件列表"),
+  groupNameMap: z.record(z.string()).optional().describe("组名映射"),
+  labelList: z.array(z.object({}).passthrough()).optional().describe("标签列表"),
+  labelPolicy: z.string().optional().describe("标签策略"),
+  placeholderList: z.array(z.object({}).passthrough()).optional().describe("占位符列表"),
 });
 
 export const UpdateAppOrchestrationResponseSchema = z.union([

--- a/tool-handlers/appstack-orchestrations.ts
+++ b/tool-handlers/appstack-orchestrations.ts
@@ -1,4 +1,4 @@
-import { 
+import {
   getLatestOrchestration,
   listAppOrchestration,
   createAppOrchestration,

--- a/tool-registry/appstack-orchestrations.ts
+++ b/tool-registry/appstack-orchestrations.ts
@@ -37,7 +37,7 @@ export const getAppStackOrchestrationTools = () => [
   },
   {
     name: 'update_app_orchestration',
-    description: '[application delivery] Update an application orchestration',
+    description: '[application delivery] Update an application orchestration. This is a full replacement — fields not provided will be cleared. Always call get_app_orchestration first and include all existing fields (especially placeholderList, labelList, componentList, groupNameMap, labelPolicy) to avoid data loss.',
     inputSchema: zodToJsonSchema(UpdateAppOrchestrationRequestSchema),
   }
 ];


### PR DESCRIPTION
placeholderList, labelList, labelPolicy, componentList, and groupNameMap were missing from the update request schema. Zod strips unknown keys, so these fields were silently dropped on every PUT, causing the backend to clear placeholder and label data.